### PR TITLE
fix: restrict face registration by event log access

### DIFF
--- a/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsAddressModel.kt
+++ b/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsAddressModel.kt
@@ -14,5 +14,6 @@ data class SettingsAddressModel(
     var services: List<String>,
     var lcab: String?,
     var hasGates: Boolean,
+    var hasPlog: Boolean,
     var isExpanded: Boolean = false
 )

--- a/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsViewModel.kt
+++ b/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsViewModel.kt
@@ -114,6 +114,7 @@ class SettingsViewModel(
                         settingItem.services,
                         settingItem.lcab,
                         settingItem.hasGates,
+                        settingItem.hasPlog,
                         expandedFlatId.contains(settingItem.flatId)
                     )
                 }

--- a/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/accessAddress/AccessAddressFragment.kt
+++ b/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/accessAddress/AccessAddressFragment.kt
@@ -57,6 +57,7 @@ class AccessAddressFragment : Fragment() {
     private var address: String = ""
     private var flatOwner: Boolean = false
     private var hasGates: Boolean = false
+    private var hasPlog: Boolean = false
     private var hasLprs: Boolean = false
     private var clientId: String = ""
 
@@ -76,6 +77,7 @@ class AccessAddressFragment : Fragment() {
             address = AccessAddressFragmentArgs.fromBundle(it).address
             flatOwner = AccessAddressFragmentArgs.fromBundle(it).flatOwner
             hasGates = AccessAddressFragmentArgs.fromBundle(it).hasGates
+            hasPlog = AccessAddressFragmentArgs.fromBundle(it).hasPlog
             clientId = AccessAddressFragmentArgs.fromBundle(it).clientId
         }
 
@@ -108,6 +110,7 @@ class AccessAddressFragment : Fragment() {
             val action = AccessAddressFragmentDirections
                 .actionAccessAddressFragmentToFaceSettingsFragment(address)
             action.flatId = flatId
+            action.canAddFace = hasPlog
             this.findNavController().navigate(action)
         }
     }

--- a/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/faceSettings/FaceSettingsFragment.kt
+++ b/presentation/src/main/java/com/sesameware/smartyard_oem/ui/main/settings/faceSettings/FaceSettingsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
@@ -26,6 +27,7 @@ class FaceSettingsFragment : Fragment() {
     private val mEventLogVM by sharedViewModel<EventLogViewModel>()
     private var flatId = 0
     private var address = ""
+    private var canAddFace = false
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?): View {
@@ -39,8 +41,12 @@ class FaceSettingsFragment : Fragment() {
         arguments?.let {
             flatId = FaceSettingsFragmentArgs.fromBundle(it).flatId
             address = FaceSettingsFragmentArgs.fromBundle(it).address
+            canAddFace = FaceSettingsFragmentArgs.fromBundle(it).canAddFace
             mViewModel.listFaces(flatId, true)
         }
+
+        binding.ivFSAddFace.isVisible = canAddFace
+        binding.tvFSComments.isVisible = canAddFace
 
         binding.ivFaceSettingsBack.setOnClickListener {
             this.findNavController().popBackStack()
@@ -54,6 +60,8 @@ class FaceSettingsFragment : Fragment() {
         initObservers()
 
         binding.ivFSAddFace.setOnClickListener {
+            if (!canAddFace) return@setOnClickListener
+
             mEventLogVM.address = address
             mEventLogVM.flatsAll = listOf(Flat(flatId, "", true))
             mEventLogVM.filterFlat = null

--- a/presentation/src/main/res/navigation/settings.xml
+++ b/presentation/src/main/res/navigation/settings.xml
@@ -91,6 +91,10 @@
             app:argType="boolean"
             android:defaultValue="false" />
         <argument
+            android:name="hasPlog"
+            app:argType="boolean"
+            android:defaultValue="false" />
+        <argument
             android:name="clientId"
             app:argType="string"/>
         <action
@@ -182,6 +186,10 @@
         <argument
             android:name="address"
             app:argType="string" />
+        <argument
+            android:name="canAddFace"
+            app:argType="boolean"
+            android:defaultValue="false" />
     </fragment>
     <fragment
         android:id="@+id/customWebViewFragmentSettings"

--- a/presentation/src/teledom/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsAddressDelegate.kt
+++ b/presentation/src/teledom/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsAddressDelegate.kt
@@ -25,7 +25,14 @@ class SettingsAddressDelegate(
     var activity: Activity,
     private val settingAddressListener: (address: String, flatId: Int, isKey: Boolean, flatOwner: Boolean, clientId: String) -> Unit,
     private val clickItem: (serviceType: Services, model: SettingsAddressModel, isCon: Boolean) -> Unit,
-    private val provideAccessListener: (address: String, flatId: Int, flatOwner: Boolean, hasGate: Boolean, clientId: String) -> Unit,
+    private val provideAccessListener: (
+        address: String,
+        flatId: Int,
+        flatOwner: Boolean,
+        hasGate: Boolean,
+        hasPlog: Boolean,
+        clientId: String
+    ) -> Unit,
     private val clickPos: (pos: Int, isExpanded: Boolean) -> Unit
 ) :
     AdapterDelegate<List<SettingsAddressModel>>() {
@@ -76,7 +83,14 @@ class SettingsAddressDelegate(
             }
 
             holder.llProvideAccess.setOnClickListener {
-                provideAccessListener.invoke(address, flatId, flatOwner, hasGates, clientId)
+                provideAccessListener.invoke(
+                    address,
+                    flatId,
+                    flatOwner,
+                    hasGates,
+                    hasPlog,
+                    clientId
+                )
             }
 
             holder.llSettingAddress.setOnClickListener {

--- a/presentation/src/teledom/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsFragment.kt
+++ b/presentation/src/teledom/java/com/sesameware/smartyard_oem/ui/main/settings/SettingsFragment.kt
@@ -128,7 +128,7 @@ class SettingsFragment : Fragment() {
                     this.findNavController().navigate(action)
                 },
                 mViewModel::getAccess,
-                { address, flatId, flatOwner, hasGates, clientId ->
+                { address, flatId, flatOwner, hasGates, hasPlog, clientId ->
                     val action =
                         SettingsFragmentDirections.actionSettingsFragmentToAccessAddressFragment(
                             "",
@@ -138,6 +138,7 @@ class SettingsFragment : Fragment() {
                     action.flatId = flatId
                     action.flatOwner = flatOwner
                     action.hasGates = hasGates
+                    action.hasPlog = hasPlog
                     action.clientId = clientId
                     this.findNavController().navigate(action)
                 },


### PR DESCRIPTION
## What changed

- Pass `hasPlog` availability from address settings to face settings.
- Hide face registration controls when the subscriber cannot access the event log.
- Keep already registered faces visible for non-owner subscribers.
- Guard navigation to the event log when face registration is unavailable.

## Why

Faces can only be registered from event log entries. Subscribers without event log access should still be able to view registered faces, but should not see or invoke registration controls.

## Validation

- `xmllint --noout presentation/src/main/res/navigation/settings.xml`
- `git diff --check`
- Static review of the `hasPlog` / `canAddFace` propagation path

Build was not run.